### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: node_js
+branches:
+  only:
+  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+node_js:
+- 9
+- node
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-numeric-range",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Takes a string, such as \"1,2,3-10,5-8\" and turns it into an array of numbers",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "utility",
     "arrays"
   ],
-  "author": "Euank",
+  "author": "Euan Kemp",
   "license": "ISC",
   "homepage": "https://github.com/euank/node-parse-numeric-range",
   "repository": {


### PR DESCRIPTION
The previous change raises the minimum nodejs version required for this
package, so I think it's fair to mark it as incompatible in semver.

Also, this package hasn't changed in years, so a 1.0 release seems
appropriate.